### PR TITLE
Enhance Procfile.dev with job worker

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,3 @@
 web: bin/rails server
 css: bin/rails tailwindcss:watch
+jobs: bin/jobs start

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ bin/rails db:prepare
 
 # 4. Run
 bin/dev
+# bin/dev uses Foreman with Procfile.dev to run the Rails server,
+# TailwindCSS watcher, and job processor. Add new processes to
+# Procfile.dev as needed.
 bundle exec rspec
 ```
 

--- a/bin/dev
+++ b/bin/dev
@@ -8,6 +8,8 @@ fi
 # Default to port 3000 if not specified
 export PORT="${PORT:-3000}"
 
+# Foreman reads Procfile.dev to start multiple services at once
+# (Rails server, Tailwind watcher, jobs, etc).
 # Let the debug gem allow remote connections,
 # but avoid loading until `debugger` is called
 export RUBY_DEBUG_OPEN="true"


### PR DESCRIPTION
## Summary
- run Solid Queue job processor alongside server and CSS watcher in Procfile.dev
- document use of Foreman in README
- note Procfile.dev usage inside bin/dev script

## Testing
- `bundle exec rspec` *(fails: PG::ConnectionBad - connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed)*
- `bundle exec rubocop`